### PR TITLE
增加cert模块，支持国密SM2证书的颁发和导入，测试见issueCertificate()，本地gradle clean build s…

### DIFF
--- a/src/main/java/twgc/gm/cert/CertSNAllocator.java
+++ b/src/main/java/twgc/gm/cert/CertSNAllocator.java
@@ -1,0 +1,13 @@
+package twgc.gm.cert;
+
+import java.math.BigInteger;
+
+/**
+ * @author liqs
+ * @version 1.0
+ * @date 2021/1/19 14:27
+ * ref：https://github.com/ZZMarquis/gmhelper
+ */
+public interface CertSNAllocator {
+    BigInteger nextSerialNumber() throws Exception;
+}

--- a/src/main/java/twgc/gm/cert/RandomSNAllocator.java
+++ b/src/main/java/twgc/gm/cert/RandomSNAllocator.java
@@ -1,0 +1,69 @@
+package twgc.gm.cert;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+
+/**
+ * @author liqs
+ * @version 1.0
+ * @date 2021/1/19 14:31
+ * ref：https://github.com/ZZMarquis/gmhelper
+ */
+public class RandomSNAllocator implements CertSNAllocator {
+    /**
+     * The highest bit is always set to 1, so the effective bit length is bitLen - 1. To ensure that
+     * at least 64 bit entropy, bitLen must be at least 65.
+     */
+    private static final int MIN_SERIALNUMBER_SIZE = 65;
+
+    /**
+     * Since serial number should be positive and maximal 20 bytes, the maximal value of bitLen is
+     * 159.
+     */
+    private static final int MAX_SERIALNUMBER_SIZE = 159;
+
+    private static int[]  andMasks = new int[] {0xFF, 0x01, 0x03, 0x07, 0x0F, 0x1F, 0x3F, 0x7F};
+
+    private static int[]  orMasks = new int[] {0x80, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40};
+
+    private final SecureRandom random;
+
+    private final int bitLen;
+
+    /**
+     * Constructor with the bitLen = 65.
+     */
+    public RandomSNAllocator() {
+        this(MIN_SERIALNUMBER_SIZE);
+    }
+
+    /**
+     * Constructor with the specification of bitLen.
+     * @param bitLen bit length of the serial number. The highest bit is always set to 1, so the
+     *        effective bit length is bitLen - 1. Valid value is [65, 159].
+     */
+    public RandomSNAllocator(int bitLen) {
+        if (bitLen < MIN_SERIALNUMBER_SIZE || bitLen > MAX_SERIALNUMBER_SIZE) {
+            throw new IllegalArgumentException(String.format(
+                    "%s may not be out of the range [%d, %d]: %d",
+                    "bitLen", MIN_SERIALNUMBER_SIZE, MAX_SERIALNUMBER_SIZE, bitLen));
+        }
+
+        this.random = new SecureRandom();
+        this.bitLen = bitLen;
+    }
+
+    @Override
+    public BigInteger nextSerialNumber() {
+        final byte[] rdnBytes = new byte[(bitLen + 7) / 8];
+        final int ci = bitLen % 8;
+
+        random.nextBytes(rdnBytes);
+        if (ci != 0) {
+            rdnBytes[0] = (byte) (rdnBytes[0] & andMasks[ci]);
+        }
+        rdnBytes[0] = (byte) (rdnBytes[0] | orMasks[ci]);
+
+        return new BigInteger(1, rdnBytes);
+    }
+}

--- a/src/main/java/twgc/gm/cert/SM2X509CertMaker.java
+++ b/src/main/java/twgc/gm/cert/SM2X509CertMaker.java
@@ -1,0 +1,239 @@
+package twgc.gm.cert;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.DERIA5String;
+import org.bouncycastle.asn1.x500.AttributeTypeAndValue;
+import org.bouncycastle.asn1.x500.RDN;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.bouncycastle.asn1.x500.style.IETFUtils;
+import org.bouncycastle.asn1.x509.*;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+
+/**
+ * @author liqs
+ * @version 1.0
+ * @date 2021/1/19 14:26
+ * ref：https://github.com/ZZMarquis/gmhelper
+ */
+public class SM2X509CertMaker {
+
+    private enum CertLevel {
+        RootCA,
+        SubCA,
+        EndEntity
+    } // class CertLevel
+
+    private static final String SIGN_ALGO_SM3WITHSM2 = "SM3WITHSM2";
+    private long certExpire;
+    private X500Name issuerDN;
+    private CertSNAllocator snAllocator;
+    private KeyPair issuerKeyPair;
+    private String commonName;
+    private List<GeneralName> subjectAltNames = new LinkedList<>();
+    private boolean selfSignedEECert;
+
+    /**
+     * @param issuerKeyPair 证书颁发者的密钥对。
+     *                      其实一般的CA的私钥都是要严格保护的。
+     *                      一般CA的私钥都会放在加密卡/加密机里，证书的签名由加密卡/加密机完成。
+     *                      这里仅是为了演示BC库签发证书的用法，所以暂时不作太多要求。
+     * @param certExpire    证书有效时间，单位毫秒
+     * @param issuer        证书颁发者信息
+     * @param snAllocator   维护/分配证书序列号的实例，证书序列号应该递增且不重复
+     */
+    public SM2X509CertMaker(KeyPair issuerKeyPair, long certExpire, X500Name issuer,
+                            CertSNAllocator snAllocator) {
+        this.issuerKeyPair = issuerKeyPair;
+        this.certExpire = certExpire;
+        this.issuerDN = issuer;
+        this.snAllocator = snAllocator;
+    }
+
+    /**
+     * 生成根CA证书
+     *
+     * @param csr CSR
+     * @return 新的证书
+     * @throws Exception 如果错误发生
+     */
+    public X509Certificate makeRootCACert(byte[] csr)
+            throws Exception {
+        KeyUsage usage = new KeyUsage(KeyUsage.keyCertSign | KeyUsage.cRLSign);
+        return makeCertificate(CertLevel.RootCA, null, csr, usage, null);
+    }
+
+    /**
+     * 生成SubCA证书
+     *
+     * @param csr CSR
+     * @return 新的证书
+     * @throws Exception 如果错误发生
+     */
+    public X509Certificate makeSubCACert(byte[] csr)
+            throws Exception {
+        KeyUsage usage = new KeyUsage(KeyUsage.keyCertSign | KeyUsage.cRLSign);
+        return makeCertificate(CertLevel.SubCA, 0, csr, usage, null);
+    }
+
+    /**
+     *
+     * @param certLevel
+     * @param pathLenConstrain
+     * @param csr               CSR
+     * @param keyUsage          证书用途
+     * @param extendedKeyUsages
+     * @return
+     * @throws Exception
+     */
+    private X509Certificate makeCertificate(CertLevel certLevel, Integer pathLenConstrain,
+                                            byte[] csr, KeyUsage keyUsage, KeyPurposeId[] extendedKeyUsages) throws Exception {
+        if (certLevel == CertLevel.EndEntity) {
+            if (keyUsage.hasUsages(KeyUsage.keyCertSign)) {
+                throw new IllegalArgumentException("keyusage keyCertSign is not allowed in EndEntity Certificate");
+            }
+        }
+        PKCS10CertificationRequest request = new PKCS10CertificationRequest(csr);
+        SubjectPublicKeyInfo subPub = request.getSubjectPublicKeyInfo();
+        X509v3CertificateBuilder v3CertGen = genX509v3CertificateBuilder(certLevel, request);
+
+        JcaX509ExtensionUtils extUtils = new JcaX509ExtensionUtils();
+        v3CertGen.addExtension(Extension.subjectKeyIdentifier, false, extUtils.createSubjectKeyIdentifier(subPub));
+        if (certLevel != CertLevel.RootCA && !selfSignedEECert) {
+            v3CertGen.addExtension(Extension.authorityKeyIdentifier, false,
+                    extUtils.createAuthorityKeyIdentifier(SubjectPublicKeyInfo.getInstance(issuerKeyPair.getPublic().getEncoded())));
+        }
+
+        BasicConstraints basicConstraints;
+        if (certLevel == CertLevel.EndEntity) {
+            basicConstraints = new BasicConstraints(false);
+        } else {
+            basicConstraints = pathLenConstrain == null ? new BasicConstraints(true) : new BasicConstraints(pathLenConstrain.intValue());
+        }
+        v3CertGen.addExtension(Extension.basicConstraints, true, basicConstraints);
+        v3CertGen.addExtension(Extension.keyUsage, true, keyUsage);
+
+        if (extendedKeyUsages != null) {
+            ExtendedKeyUsage xku = new ExtendedKeyUsage(extendedKeyUsages);
+            v3CertGen.addExtension(Extension.extendedKeyUsage, false, xku);
+            boolean forSSLServer = false;
+            for (KeyPurposeId purposeId : extendedKeyUsages) {
+                if (KeyPurposeId.id_kp_serverAuth.equals(purposeId)) {
+                    forSSLServer = true;
+                    break;
+                }
+            }
+            if (forSSLServer) {
+                if (commonName == null) {
+                    throw new IllegalArgumentException("commonName must not be null");
+                }
+                GeneralName name = new GeneralName(GeneralName.dNSName, new DERIA5String(commonName, true));
+                subjectAltNames.add(name);
+            }
+        }
+
+        if (!subjectAltNames.isEmpty()) {
+            v3CertGen.addExtension(Extension.subjectAlternativeName, false,
+                    new GeneralNames(subjectAltNames.toArray(new GeneralName[0])));
+        }
+
+        JcaContentSignerBuilder contentSignerBuilder = makeContentSignerBuilder(issuerKeyPair.getPublic());
+        X509Certificate cert = new JcaX509CertificateConverter().setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .getCertificate(v3CertGen.build(contentSignerBuilder.build(issuerKeyPair.getPrivate())));
+        cert.verify(issuerKeyPair.getPublic());
+        return cert;
+    }
+
+    private JcaContentSignerBuilder makeContentSignerBuilder(PublicKey issPub) throws Exception {
+        if (issPub.getAlgorithm().equals("EC")) {
+            JcaContentSignerBuilder contentSignerBuilder = new JcaContentSignerBuilder(SIGN_ALGO_SM3WITHSM2);
+            contentSignerBuilder.setProvider(BouncyCastleProvider.PROVIDER_NAME);
+            return contentSignerBuilder;
+        }
+        throw new Exception("Unsupported PublicKey Algorithm:" + issPub.getAlgorithm());
+    }
+
+    private X509v3CertificateBuilder genX509v3CertificateBuilder(CertLevel certLevel, PKCS10CertificationRequest request) throws Exception {
+
+        SubjectPublicKeyInfo subPub = request.getSubjectPublicKeyInfo();
+
+        X500Name subject = request.getSubject();
+        String email = null;
+        /*
+         * RFC 5280 §4.2.1.6 Subject
+         *  Conforming implementations generating new certificates with
+         *  electronic mail addresses MUST use the rfc822Name in the subject
+         *  alternative name extension (Section 4.2.1.6) to describe such
+         *  identities.  Simultaneous inclusion of the emailAddress attribute in
+         *  the subject distinguished name to support legacy implementations is
+         *  deprecated but permitted.
+         */
+        RDN[] rdns = subject.getRDNs();
+        List<RDN> newRdns = new ArrayList<>(rdns.length);
+        for (int i = 0; i < rdns.length; i++) {
+            RDN rdn = rdns[i];
+
+            AttributeTypeAndValue atv = rdn.getFirst();
+            ASN1ObjectIdentifier type = atv.getType();
+            if (BCStyle.EmailAddress.equals(type)) {
+                email = IETFUtils.valueToString(atv.getValue());
+            } else {
+                if (BCStyle.CN.equals(type)) {
+                    commonName = IETFUtils.valueToString(atv.getValue());
+                }
+                newRdns.add(rdn);
+            }
+        }
+
+        if (email != null) {
+            subject = new X500Name(newRdns.toArray(new RDN[0]));
+            subjectAltNames.add(
+                    new GeneralName(GeneralName.rfc822Name,
+                            new DERIA5String(email, true)));
+        }
+
+        switch (certLevel) {
+            case RootCA:
+                if (issuerDN.equals(subject)) {
+                    subject = issuerDN;
+                } else {
+                    throw new IllegalArgumentException("subject != issuer for certLevel " + CertLevel.RootCA);
+                }
+                break;
+            case SubCA:
+                if (issuerDN.equals(subject)) {
+                    throw new IllegalArgumentException(
+                            "subject MUST not equals issuer for certLevel " + certLevel);
+                }
+                break;
+            default:
+                if (issuerDN.equals(subject)) {
+                    selfSignedEECert = true;
+                    subject = issuerDN;
+                }
+        }
+
+        BigInteger serialNumber = snAllocator.nextSerialNumber();
+        Date notBefore = new Date();
+        Date notAfter = new Date(notBefore.getTime() + certExpire);
+        return new X509v3CertificateBuilder(
+                issuerDN, serialNumber,
+                notBefore, notAfter,
+                subject, subPub);
+    }
+
+}

--- a/src/main/java/twgc/gm/sm2/SM2Util.java
+++ b/src/main/java/twgc/gm/sm2/SM2Util.java
@@ -1,10 +1,15 @@
 package twgc.gm.sm2;
 
+import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.math.BigInteger;
 import java.security.*;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.security.spec.ECGenParameterSpec;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
@@ -190,6 +195,16 @@ public class SM2Util {
         return str.toString();
     }
 
+    public static String pemFrom(X509Certificate x509Certificate) throws IOException, CertificateEncodingException {
+        PemObject pem = new PemObject("CERTIFICATE", x509Certificate.getEncoded());
+        StringWriter str = new StringWriter();
+        PemWriter pemWriter = new PemWriter(str);
+        pemWriter.writeObject(pem);
+        pemWriter.close();
+        str.close();
+        return str.toString();
+    }
+
     public static PrivateKey loadPrivFromFile(String filename, String password) throws IOException, OperatorCreationException, PKCSException {
         FileReader fr = new FileReader(filename);
         PEMParser pemReader = new PEMParser(fr);
@@ -217,6 +232,18 @@ public class SM2Util {
         PemObject spki = new PemReader(fr).readPemObject();
         fr.close();
         return KeyFactory.getInstance(EC_VALUE, BouncyCastleProvider.PROVIDER_NAME).generatePublic(new X509EncodedKeySpec(spki.getContent()));
+    }
+
+    public static X509Certificate loadX509CertificateFromFile(String filename) throws IOException, CertificateException,
+            NoSuchProviderException {
+        FileInputStream in = null;
+        try {
+            in = new FileInputStream(filename);
+            CertificateFactory cf = CertificateFactory.getInstance("X.509", BouncyCastleProvider.PROVIDER_NAME);
+            return (X509Certificate) cf.generateCertificate(in);
+        } finally {
+            in.close();
+        }
     }
 
     public static PublicKey derivePublicFromPrivate(PrivateKey privateKey) {

--- a/src/test/java/SM2UtilTest.java
+++ b/src/test/java/SM2UtilTest.java
@@ -3,10 +3,15 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.*;
+import java.security.cert.X509Certificate;
 import javax.security.auth.x500.X500Principal;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x500.X500NameBuilder;
+import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.crypto.engines.SM2Engine;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.junit.Assert;
@@ -14,6 +19,9 @@ import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
+import twgc.gm.cert.CertSNAllocator;
+import twgc.gm.cert.RandomSNAllocator;
+import twgc.gm.cert.SM2X509CertMaker;
 import twgc.gm.sm2.SM2Util;
 
 
@@ -24,6 +32,7 @@ public class SM2UtilTest {
     static String privFileName = "priv.pem";
     static String encryptedprivFileName = "encryptedpriv.pem";
     static String reqFileName = "req.pem";
+    static String certFileName = "cert.pem";
     static String exceptionHappened = "Exception happened";
     static String keyEqualHint = "key should be equal";
     static String passwd = RandomStringUtils.random(18);
@@ -31,12 +40,24 @@ public class SM2UtilTest {
     static byte[] message = RandomStringUtils.random(randomData).getBytes();
     PublicKey pubKey;
     PrivateKey privKey;
+    X509Certificate x509Certificate;
     KeyPair keyPair;
 
-    public static void saveCSRInPem(KeyPair keyPair, X500Principal subject, String csrFile) throws IOException, OperatorCreationException {
-        PKCS10CertificationRequest csr = SM2Util.generateCSR(keyPair, subject);
+    public static void saveCSRInPem(PKCS10CertificationRequest csr, String csrFile) throws IOException, OperatorCreationException {
         String csrPem = SM2Util.pemFrom(csr);
         Files.write(Paths.get(csrFile), csrPem.getBytes());
+    }
+
+    public static void saveCertificateInPem(X509Certificate x509Certificate, String certFileName) throws Exception {
+        String certStr = SM2Util.pemFrom(x509Certificate);
+        Files.write(Paths.get(certFileName), certStr.getBytes());
+    }
+
+    public static X509Certificate genCertificate(KeyPair keyPair, PKCS10CertificationRequest csr, X500Name x500Name) throws Exception {
+        long certExpire = 20L * 365 * 24 * 60 * 60 * 1000;
+        CertSNAllocator snAllocator = new RandomSNAllocator();
+        SM2X509CertMaker rootCertMaker = new SM2X509CertMaker(keyPair, certExpire, x500Name, snAllocator);
+        return rootCertMaker.makeRootCACert(csr.getEncoded());
     }
 
     public static void savePemFormatKeyFile(PrivateKey privateKey, String filename) throws IOException, OperatorCreationException {
@@ -60,12 +81,21 @@ public class SM2UtilTest {
         File pubFile = new File(pubFileName);
         File privFile = new File(privFileName);
         File reqFile = new File(reqFileName);
+        File certFile = new File(certFileName);
         try {
             if (!pubFile.exists()) {
                 SM2Util instance = new SM2Util();
                 this.keyPair = instance.generatekeyPair();
                 saveKeyPairInPem(this.keyPair, pubFileName, privFileName);
-                saveCSRInPem(this.keyPair, new X500Principal("C=CN"), reqFileName);
+
+                X500NameBuilder builder = new X500NameBuilder(BCStyle.INSTANCE);
+                X500Name x500Name = builder.addRDN(BCStyle.CN, "Root CA").build();
+                // gen csr && save
+                PKCS10CertificationRequest csr = SM2Util.generateCSR(keyPair, new X500Principal(String.valueOf(x500Name)));
+                saveCSRInPem(csr, reqFileName);
+                // gen cert && save
+                X509Certificate x509Certificate = genCertificate(keyPair, csr, x500Name);
+                saveCertificateInPem(x509Certificate, certFileName);
             } else {
                 System.out.println("Skip file generation deal to interact testing.");
             }
@@ -73,6 +103,9 @@ public class SM2UtilTest {
             Assert.assertNotNull(this.pubKey);
             this.privKey = SM2Util.loadPrivFromFile(privFileName, "");
             Assert.assertNotNull(this.privKey);
+            this.x509Certificate = SM2Util.loadX509CertificateFromFile(certFileName);
+            Assert.assertNotNull(this.x509Certificate);
+            Assert.assertEquals("SM3WITHSM2", this.x509Certificate.getSigAlgName());
             if (!pubFile.exists()) {
                 Assert.assertEquals(keyEqualHint, this.keyPair.getPublic(), this.pubKey);
                 Assert.assertEquals(keyEqualHint, this.keyPair.getPrivate(), this.privKey);
@@ -84,6 +117,7 @@ public class SM2UtilTest {
         Assert.assertTrue(pubFile.exists());
         Assert.assertTrue(privFile.exists());
         Assert.assertTrue(reqFile.exists());
+        Assert.assertTrue(certFile.exists());
     }
 
     //encrypt and decrypt
@@ -180,6 +214,54 @@ public class SM2UtilTest {
         } catch (Exception e) {
             e.printStackTrace();
             Assert.fail(exceptionHappened);
+        }
+    }
+
+    @Test
+    public void issueCertificate() throws Exception {
+
+        SM2Util sm2Util = new SM2Util();
+        // 证书颁发时长
+        long certExpire = 20L * 365 * 24 * 60 * 60 * 1000;
+        CertSNAllocator snAllocator = new RandomSNAllocator();
+
+        // one 模拟根 CA 自签名生成根证书 rootCACert
+        KeyPair rootKeyPair = sm2Util.generatekeyPair();
+        X500Name rootX500Name = new X500NameBuilder(BCStyle.INSTANCE).addRDN(BCStyle.CN, "Root CA").build();
+        SM2X509CertMaker rootCertMaker = new SM2X509CertMaker(rootKeyPair, certExpire, rootX500Name, snAllocator);
+        PublicKey rootKeyPairPublic = rootKeyPair.getPublic();
+        byte[] rootcsr = SM2Util.generateCSR(rootKeyPair, new X500Principal(String.valueOf(rootX500Name))).getEncoded();
+        X509Certificate rootCACert = rootCertMaker.makeRootCACert(rootcsr);
+
+        // two 模拟根 CA 生成中间证书
+        KeyPair midKeyPair = sm2Util.generatekeyPair();
+        PublicKey midKeyPairPublic = midKeyPair.getPublic();
+        X500Name midX500Name = new X500NameBuilder(BCStyle.INSTANCE).addRDN(BCStyle.CN, "Intermediate CA").build();
+        byte[] midcsr = SM2Util.generateCSR(midKeyPair, new X500Principal(String.valueOf(midX500Name))).getEncoded();
+        X509Certificate midCACert = rootCertMaker.makeSubCACert(midcsr);
+
+        // three 模拟中间 CA 生成用户证书
+        SM2X509CertMaker midCertMaker = new SM2X509CertMaker(midKeyPair, certExpire, midX500Name, snAllocator);
+        KeyPair userKeyPair = sm2Util.generatekeyPair();
+        X500Name userX500Name = new X500NameBuilder(BCStyle.INSTANCE).addRDN(BCStyle.CN, "User CA").build();
+        byte[] usercsr = SM2Util.generateCSR(userKeyPair, new X500Principal(String.valueOf(userX500Name))).getEncoded();
+        X509Certificate userCACert = midCertMaker.makeSubCACert(usercsr);
+
+        // 根证书自签名，用自己的公钥验证
+        rootCACert.verify(rootKeyPairPublic, BouncyCastleProvider.PROVIDER_NAME);
+        // 中间证书可用根证书的公钥验证
+        midCACert.verify(rootKeyPairPublic, BouncyCastleProvider.PROVIDER_NAME);
+        // 用户证书可用中间证书的公钥验证
+        userCACert.verify(midKeyPairPublic, BouncyCastleProvider.PROVIDER_NAME);
+
+    }
+
+    // 静态代码块，避免运行 generateFile() 后再次运行报错
+    static {
+        try {
+            Security.addProvider(new BouncyCastleProvider());
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 }


### PR DESCRIPTION
1、增加twgc.gm.cert ，支持国密SM2证书的颁发和导入，测试见generateFile()和issueCertificate()
2、新增静态代码块，避免第一次运行 generateFile()成功，但再次运行报错，报错如下“”java.security.NoSuchProviderException: no such provider: BC“”