### PR TITLE
Avoid frequent initializations of the static KeyPairGenerator's ins…

### DIFF
--- a/src/main/java/twgc/gm/sm2/SM2Util.java
+++ b/src/main/java/twgc/gm/sm2/SM2Util.java
@@ -58,12 +58,13 @@ import org.bouncycastle.util.io.pem.PemWriter;
  */
 public class SM2Util {
 
-    public SM2Util() throws NoSuchProviderException, NoSuchAlgorithmException {
+    public SM2Util() throws NoSuchProviderException, NoSuchAlgorithmException, InvalidAlgorithmParameterException {
         if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
             Security.addProvider(new BouncyCastleProvider());
         }
         signature = Signature.getInstance(SM3SM2_VALUE, BouncyCastleProvider.PROVIDER_NAME);
         generator = KeyPairGenerator.getInstance(EC_VALUE, BouncyCastleProvider.PROVIDER_NAME);
+        generator.initialize(new ECGenParameterSpec(CURVE_NAME));
     }
 
     public SM2Engine getSm2Engine() {
@@ -100,8 +101,7 @@ public class SM2Util {
      * @return RSA P10 证书请求 Base64 字符串
      * @throws InvalidAlgorithmParameterException 当采用的 ECC 算法不适用于该密钥对生成器时
      */
-    public KeyPair generatekeyPair() throws InvalidAlgorithmParameterException {
-        generator.initialize(new ECGenParameterSpec(CURVE_NAME));
+    public KeyPair generatekeyPair() {
         return generator.generateKeyPair();
     }
 

--- a/src/test/java/SM2UtilThreadTest.java
+++ b/src/test/java/SM2UtilThreadTest.java
@@ -1,4 +1,6 @@
 import java.security.*;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -98,6 +100,20 @@ public class SM2UtilThreadTest {
         } catch (Exception e) {
             e.printStackTrace();
             Assert.fail(exceptionHappened);
+        }
+    }
+
+    @Test
+    public void testKeyGen() {
+        try {
+            SM2Util instance = new SM2Util();
+            Instant start = Instant.now();
+            for (int i = 0; i < 1000; i++) {
+                instance.generatekeyPair();
+            }
+            System.out.println("cost ms: " + Duration.between(start, Instant.now()).toMillis());
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION
Avoid frequent initializations of the static KeyPairGenerator's instance，only once. Byside, it helps a little with performance.

Signed-off-by: Xiao Hui <xiaohui_1123@126.com>