### PR TITLE
feat: SM2Util 支持通过密钥对和证书的字符串形式加载其对象

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,13 +38,13 @@ check.dependsOn 'checkstyle'
 
 jacoco {
     toolVersion = "0.8.5"
-    reportsDirectory = layout.buildDirectory.dir('customJacocoReportDir')
+    reportsDir = file("$buildDir/customJacocoReportDir")
 }
 
 jacocoTestReport {
     reports {
-        xml.required = false
-        csv.required = false
+        xml.enabled false
+        csv.enabled false
         html.destination file("${buildDir}/jacocoHtml")
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -38,13 +38,13 @@ check.dependsOn 'checkstyle'
 
 jacoco {
     toolVersion = "0.8.5"
-    reportsDir = file("$buildDir/customJacocoReportDir")
+    reportsDirectory = layout.buildDirectory.dir('customJacocoReportDir')
 }
 
 jacocoTestReport {
     reports {
-        xml.enabled false
-        csv.enabled false
+        xml.required = false
+        csv.required = false
         html.destination file("${buildDir}/jacocoHtml")
     }
 }

--- a/src/main/java/twgc/gm/sm2/SM2Util.java
+++ b/src/main/java/twgc/gm/sm2/SM2Util.java
@@ -1,6 +1,5 @@
 package twgc.gm.sm2;
 
-import javax.security.auth.x500.X500Principal;
 import java.io.*;
 import java.math.BigInteger;
 import java.security.*;
@@ -12,6 +11,8 @@ import java.security.spec.ECGenParameterSpec;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.function.Supplier;
+import javax.security.auth.x500.X500Principal;
+
 import org.bouncycastle.asn1.gm.GMNamedCurves;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.asn1.x9.X9ECParameters;

--- a/src/main/java/twgc/gm/sm2/SM2Util.java
+++ b/src/main/java/twgc/gm/sm2/SM2Util.java
@@ -263,6 +263,16 @@ public class SM2Util {
                 BouncyCastleProvider.CONFIGURATION);
     }
 
+    /**
+     * 加载私钥
+     *
+     * @param password 密码
+     * @param fx {@link Reader} 回调函数
+     * @return {@link PrivateKey}
+     * @throws IOException
+     * @throws OperatorCreationException
+     * @throws PKCSException
+     */
     public static PrivateKey loadPriv(String password, Supplier<Reader> fx) throws IOException, OperatorCreationException, PKCSException {
         PrivateKey priv = null;
         try (PEMParser pemParser = new PEMParser(fx.get())) {
@@ -283,6 +293,16 @@ public class SM2Util {
         return priv;
     }
 
+    /**
+     * 加载公钥
+     *
+     * @param fx {@link Reader} 回调函数
+     * @return {@link PublicKey}
+     * @throws IOException
+     * @throws NoSuchProviderException
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidKeySpecException
+     */
     public static PublicKey loadPublic(Supplier<Reader> fx) throws IOException, NoSuchProviderException, NoSuchAlgorithmException, InvalidKeySpecException {
         try (PemReader pemReader = new PemReader(fx.get())) {
             PemObject spki = pemReader.readPemObject();

--- a/src/main/java/twgc/gm/sm2/SM2Util.java
+++ b/src/main/java/twgc/gm/sm2/SM2Util.java
@@ -1,5 +1,17 @@
 package twgc.gm.sm2;
 
+import javax.security.auth.x500.X500Principal;
+import java.io.*;
+import java.math.BigInteger;
+import java.security.*;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.function.Supplier;
 import org.bouncycastle.asn1.gm.GMNamedCurves;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.asn1.x9.X9ECParameters;
@@ -34,19 +46,6 @@ import org.bouncycastle.util.io.pem.PemReader;
 import org.bouncycastle.util.io.pem.PemWriter;
 import twgc.gm.random.SecureRandomFactory;
 import twgc.gm.utils.Const;
-
-import javax.security.auth.x500.X500Principal;
-import java.io.*;
-import java.math.BigInteger;
-import java.security.*;
-import java.security.cert.CertificateEncodingException;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
-import java.security.spec.ECGenParameterSpec;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.X509EncodedKeySpec;
-import java.util.function.Supplier;
 
 /**
  * @author SamYuan; 吴仙杰

--- a/src/test/java/SM2UtilTest.java
+++ b/src/test/java/SM2UtilTest.java
@@ -1,12 +1,3 @@
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.security.*;
-import java.security.cert.X509Certificate;
-import java.util.Date;
-import javax.security.auth.x500.X500Principal;
-
 import org.apache.commons.lang3.RandomStringUtils;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.X500NameBuilder;
@@ -25,7 +16,18 @@ import twgc.gm.random.CertSNAllocator;
 import twgc.gm.random.RandomSNAllocator;
 import twgc.gm.sm2.SM2Util;
 import twgc.gm.sm2.SM2X509CertFactory;
+import twgc.gm.utils.ConfigLoader;
 
+import javax.security.auth.x500.X500Principal;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.*;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.Map;
 
 
 @FixMethodOrder(MethodSorters.JVM)
@@ -289,6 +291,162 @@ public class SM2UtilTest {
         // 用户证书可用中间证书的公钥验证
         userCACert.verify(midKeyPairPublic, BouncyCastleProvider.PROVIDER_NAME);
 
+    }
+
+    /**
+     * 测试从 `testdata.yml` 加载配置文件
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testLoadConfigMap() throws IOException {
+        InputStream in = SM2UtilTest.class.getResourceAsStream("testdata.yml");
+        Map<String, Map<String, Object>> configMap = ConfigLoader.loadConfig(in);
+
+        Assert.assertNotNull(configMap);
+
+        Map<String, Object> javagm = configMap.get("javagm");
+        Assert.assertNotNull(javagm);
+
+        Object testdata = javagm.get("testdata");
+
+        Assert.assertNotNull(testdata);
+        String publicKey = (String) ((Map<String, Object>) testdata).get("public-key");
+        String privateKey = (String) ((Map<String, Object>) testdata).get("private-key");
+        String cert = (String) ((Map<String, Object>) testdata).get("cert");
+
+        Assert.assertNotNull(publicKey);
+        Assert.assertNotNull(privateKey);
+        Assert.assertNotNull(cert);
+    }
+
+    /**
+     * 测试从从字符串加载私钥对象
+     *
+     * <pre>
+     * javagm:
+     *   testdata:
+     *     private-key: |
+     *       -----BEGIN PRIVATE KEY-----
+     *       MIGTAgEAMBMGByqGSM49AgEGCCqBHM9VAYItBHkwdwIBAQQgc0UCgfELjC0V+xUm
+     *       ELYFmy0J0cee42ZpKyQ4FRTBlJSgCgYIKoEcz1UBgi2hRANCAATJbIFbxcAaDxMk
+     *       7XExTRU/bBnGEu6YfaleJxnLZS40NDNjZV+ztveWfLZk2+oWieykM3/yZ/6IieJk
+     *       5uuohUjD
+     *       -----END PRIVATE KEY-----
+     *     public-key: |
+     *       -----BEGIN PUBLIC KEY-----
+     *       MFkwEwYHKoZIzj0CAQYIKoEcz1UBgi0DQgAEyWyBW8XAGg8TJO1xMU0VP2wZxhLu
+     *       mH2pXicZy2UuNDQzY2Vfs7b3lny2ZNvqFonspDN/8mf+iIniZObrqIVIww==
+     *       -----END PUBLIC KEY-----
+     *     cert: |
+     *       -----BEGIN CERTIFICATE-----
+     *       MIIBdzCCAR2gAwIBAgIJAfA3Qnph7CieMAoGCCqBHM9VAYN1MBIxEDAOBgNVBAMM
+     *       B1Jvb3QgQ0EwHhcNMjMxMjAyMTQzMjMxWhcNODkxMjI3MDAwMDAwWjASMRAwDgYD
+     *       VQQDEwdSb290IENBMFkwEwYHKoZIzj0CAQYIKoEcz1UBgi0DQgAEyWyBW8XAGg8T
+     *       JO1xMU0VP2wZxhLumH2pXicZy2UuNDQzY2Vfs7b3lny2ZNvqFonspDN/8mf+iIni
+     *       ZObrqIVIw6NcMFowHQYDVR0OBBYEFOMvj2LPGlkOw1M1Pj34klVi8SFgMA8GA1Ud
+     *       EwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMBgGA1UdEQQRMA+BDXRlc3RAdHdn
+     *       Yy5jb20wCgYIKoEcz1UBg3UDSAAwRQIgTeoLjt+eP3kwQg17G+l12wj4MQNed1hW
+     *       aZZkJe43rkICIQCdI3WhnrvzhbEijsTXL1woIwnFgY9MIci7BmKLMpMM6w==
+     *       -----END CERTIFICATE-----
+     * </pre>
+     */
+    @Test
+    public void testLoadPrivFromString() throws Exception {
+        InputStream in = SM2UtilTest.class.getResourceAsStream("testdata.yml");
+        Map<String, Map<String, Object>> configMap = ConfigLoader.loadConfig(in);
+        Map<String, Object> javagm = configMap.get("javagm");
+        Object testdata = javagm.get("testdata");
+
+        // 模拟从 配置文件 (`testdata.yml` | `application.yml` | 配置中心等) 获取密钥对字符串
+        String privateKey = (String) ((Map<String, Object>) testdata).get("private-key");
+
+        PrivateKey privKey = SM2Util.loadPrivFromString(privateKey, "");
+        Assert.assertNotNull(privKey);
+    }
+
+    /**
+     * 测试从从字符串加载公钥对象
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testLoadPublicFromString() throws Exception {
+        InputStream in = SM2UtilTest.class.getResourceAsStream("testdata.yml");
+        Map<String, Map<String, Object>> configMap = ConfigLoader.loadConfig(in);
+        Map<String, Object> javagm = configMap.get("javagm");
+        Object testdata = javagm.get("testdata");
+
+        // 模拟从 配置文件 (`testdata.yml` | `application.yml` | 配置中心等) 获取密钥对字符串
+        String publicKey = (String) ((Map<String, Object>) testdata).get("public-key");
+        PublicKey pubKey = SM2Util.loadPublicFromString(publicKey);
+        Assert.assertNotNull(pubKey);
+    }
+
+    /**
+     * 测试从字符串加载密钥对并测试加解密
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testLoadPublicAndPrivFromString() throws Exception {
+        InputStream in = SM2UtilTest.class.getResourceAsStream("testdata.yml");
+        Map<String, Map<String, Object>> configMap = ConfigLoader.loadConfig(in);
+        Map<String, Object> javagm = configMap.get("javagm");
+        Object testdata = javagm.get("testdata");
+
+        // 模拟从 配置文件 (`testdata.yml` | `application.yml` | 配置中心等) 获取密钥对字符串
+        String publicKey = (String) ((Map<String, Object>) testdata).get("public-key");
+        String privateKey = (String) ((Map<String, Object>) testdata).get("private-key");
+
+        PublicKey pubKey = SM2Util.loadPublicFromString(publicKey);
+        PrivateKey privKey = SM2Util.loadPrivFromString(privateKey, "");
+
+        Assert.assertNotNull(pubKey);
+        Assert.assertNotNull(privKey);
+
+        SM2EnginePool sm2EnginePool = new SM2EnginePool(1, SM2Engine.Mode.C1C3C2);
+        SM2Engine sm2Engine = null;
+
+        try {
+            SM2Util instance = new SM2Util();
+            sm2Engine = sm2EnginePool.borrowObject();
+            byte[] encrypted = instance.encrypt(sm2Engine, pubKey, message);
+            byte[] rs = instance.decrypt(sm2Engine, privKey, encrypted);
+            Assert.assertEquals(new String(message), new String(rs));
+
+            byte[] encrypted2 = instance.encrypt(sm2Engine, pubKey, "msg".getBytes());
+            rs = instance.decrypt(sm2Engine, privKey, encrypted2);
+            Assert.assertNotEquals(new String(message), new String(rs));
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail(exceptionHappened);
+        } finally {
+            if (sm2Engine != null) {
+                sm2EnginePool.returnObject(sm2Engine);
+            }
+        }
+    }
+
+    /**
+     * 测试从字符串加载证书对象
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testLoadX509CertificateFromString() throws Exception {
+        InputStream in = SM2UtilTest.class.getResourceAsStream("testdata.yml");
+        Map<String, Map<String, Object>> configMap = ConfigLoader.loadConfig(in);
+        Map<String, Object> javagm = configMap.get("javagm");
+        Object testdata = javagm.get("testdata");
+
+        // 模拟从 配置文件 (`testdata.yml` | `application.yml` | 配置中心等) 获取证书字符串
+        String cert = (String) ((Map<String, Object>) testdata).get("cert");
+        Assert.assertNotNull(cert);
+
+        X509Certificate certificate = SM2Util.loadX509CertificateFromString(cert);
+        Assert.assertNotNull(certificate);
+        Assert.assertEquals("SM3WITHSM2", certificate.getSigAlgName());
     }
 
     static {

--- a/src/test/java/SM2UtilTest.java
+++ b/src/test/java/SM2UtilTest.java
@@ -48,6 +48,8 @@ public class SM2UtilTest {
     X509Certificate x509Certificate;
     KeyPair keyPair;
 
+    Map<String, Map<String, Object>> configMap;
+
     public static void saveCSRInPem(PKCS10CertificationRequest csr, String csrFile) throws IOException, OperatorCreationException {
         String csrPem = SM2Util.pemFrom(csr);
         Files.write(Paths.get(csrFile), csrPem.getBytes());
@@ -128,6 +130,19 @@ public class SM2UtilTest {
         Assert.assertTrue(privFile.exists());
         Assert.assertTrue(reqFile.exists());
         Assert.assertTrue(certFile.exists());
+
+    }
+
+    @Before
+    public void loadTestDataConfigMap() {
+        try {
+            InputStream in = SM2UtilTest.class.getResourceAsStream("testdata.yml");
+            this.configMap = ConfigLoader.loadConfig(in);
+
+            Assert.assertNotNull(this.configMap);
+        } catch (Exception e) {
+            Assert.fail(exceptionHappened);
+        }
     }
 
     //encrypt and decrypt
@@ -299,13 +314,8 @@ public class SM2UtilTest {
      * @throws IOException
      */
     @Test
-    public void testLoadConfigMap() throws IOException {
-        InputStream in = SM2UtilTest.class.getResourceAsStream("testdata.yml");
-        Map<String, Map<String, Object>> configMap = ConfigLoader.loadConfig(in);
-
-        Assert.assertNotNull(configMap);
-
-        Map<String, Object> javagm = configMap.get("javagm");
+    public void testLoadConfigMap() {
+        Map<String, Object> javagm = this.configMap.get("javagm");
         Assert.assertNotNull(javagm);
 
         Object testdata = javagm.get("testdata");
@@ -353,12 +363,8 @@ public class SM2UtilTest {
      */
     @Test
     public void testLoadPrivFromString() throws Exception {
-        InputStream in = SM2UtilTest.class.getResourceAsStream("testdata.yml");
-        Map<String, Map<String, Object>> configMap = ConfigLoader.loadConfig(in);
-        Map<String, Object> javagm = configMap.get("javagm");
+        Map<String, Object> javagm = this.configMap.get("javagm");
         Object testdata = javagm.get("testdata");
-
-        // 模拟从 配置文件 (`testdata.yml` | `application.yml` | 配置中心等) 获取密钥对字符串
         String privateKey = (String) ((Map<String, Object>) testdata).get("private-key");
 
         PrivateKey privKey = SM2Util.loadPrivFromString(privateKey, "");
@@ -372,12 +378,9 @@ public class SM2UtilTest {
      */
     @Test
     public void testLoadPublicFromString() throws Exception {
-        InputStream in = SM2UtilTest.class.getResourceAsStream("testdata.yml");
-        Map<String, Map<String, Object>> configMap = ConfigLoader.loadConfig(in);
-        Map<String, Object> javagm = configMap.get("javagm");
+        Map<String, Object> javagm = this.configMap.get("javagm");
         Object testdata = javagm.get("testdata");
 
-        // 模拟从 配置文件 (`testdata.yml` | `application.yml` | 配置中心等) 获取密钥对字符串
         String publicKey = (String) ((Map<String, Object>) testdata).get("public-key");
         PublicKey pubKey = SM2Util.loadPublicFromString(publicKey);
         Assert.assertNotNull(pubKey);
@@ -390,12 +393,9 @@ public class SM2UtilTest {
      */
     @Test
     public void testLoadPublicAndPrivFromString() throws Exception {
-        InputStream in = SM2UtilTest.class.getResourceAsStream("testdata.yml");
-        Map<String, Map<String, Object>> configMap = ConfigLoader.loadConfig(in);
-        Map<String, Object> javagm = configMap.get("javagm");
+        Map<String, Object> javagm = this.configMap.get("javagm");
         Object testdata = javagm.get("testdata");
 
-        // 模拟从 配置文件 (`testdata.yml` | `application.yml` | 配置中心等) 获取密钥对字符串
         String publicKey = (String) ((Map<String, Object>) testdata).get("public-key");
         String privateKey = (String) ((Map<String, Object>) testdata).get("private-key");
 
@@ -435,12 +435,9 @@ public class SM2UtilTest {
      */
     @Test
     public void testLoadX509CertificateFromString() throws Exception {
-        InputStream in = SM2UtilTest.class.getResourceAsStream("testdata.yml");
-        Map<String, Map<String, Object>> configMap = ConfigLoader.loadConfig(in);
-        Map<String, Object> javagm = configMap.get("javagm");
+        Map<String, Object> javagm = this.configMap.get("javagm");
         Object testdata = javagm.get("testdata");
 
-        // 模拟从 配置文件 (`testdata.yml` | `application.yml` | 配置中心等) 获取证书字符串
         String cert = (String) ((Map<String, Object>) testdata).get("cert");
         Assert.assertNotNull(cert);
 

--- a/src/test/java/SM2UtilTest.java
+++ b/src/test/java/SM2UtilTest.java
@@ -1,4 +1,3 @@
-import javax.security.auth.x500.X500Principal;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -8,6 +7,8 @@ import java.security.*;
 import java.security.cert.X509Certificate;
 import java.util.Date;
 import java.util.Map;
+import javax.security.auth.x500.X500Principal;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.X500NameBuilder;

--- a/src/test/java/SM2UtilTest.java
+++ b/src/test/java/SM2UtilTest.java
@@ -1,3 +1,13 @@
+import javax.security.auth.x500.X500Principal;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.*;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.Map;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.X500NameBuilder;
@@ -17,17 +27,6 @@ import twgc.gm.random.RandomSNAllocator;
 import twgc.gm.sm2.SM2Util;
 import twgc.gm.sm2.SM2X509CertFactory;
 import twgc.gm.utils.ConfigLoader;
-
-import javax.security.auth.x500.X500Principal;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.security.*;
-import java.security.cert.X509Certificate;
-import java.util.Date;
-import java.util.Map;
 
 
 @FixMethodOrder(MethodSorters.JVM)

--- a/src/test/resources/testdata.yml
+++ b/src/test/resources/testdata.yml
@@ -1,0 +1,25 @@
+javagm:
+  testdata:
+    private-key: |
+      -----BEGIN PRIVATE KEY-----
+      MIGTAgEAMBMGByqGSM49AgEGCCqBHM9VAYItBHkwdwIBAQQgc0UCgfELjC0V+xUm
+      ELYFmy0J0cee42ZpKyQ4FRTBlJSgCgYIKoEcz1UBgi2hRANCAATJbIFbxcAaDxMk
+      7XExTRU/bBnGEu6YfaleJxnLZS40NDNjZV+ztveWfLZk2+oWieykM3/yZ/6IieJk
+      5uuohUjD
+      -----END PRIVATE KEY-----
+    public-key: |
+      -----BEGIN PUBLIC KEY-----
+      MFkwEwYHKoZIzj0CAQYIKoEcz1UBgi0DQgAEyWyBW8XAGg8TJO1xMU0VP2wZxhLu
+      mH2pXicZy2UuNDQzY2Vfs7b3lny2ZNvqFonspDN/8mf+iIniZObrqIVIww==
+      -----END PUBLIC KEY-----
+    cert: |
+      -----BEGIN CERTIFICATE-----
+      MIIBdzCCAR2gAwIBAgIJAfA3Qnph7CieMAoGCCqBHM9VAYN1MBIxEDAOBgNVBAMM
+      B1Jvb3QgQ0EwHhcNMjMxMjAyMTQzMjMxWhcNODkxMjI3MDAwMDAwWjASMRAwDgYD
+      VQQDEwdSb290IENBMFkwEwYHKoZIzj0CAQYIKoEcz1UBgi0DQgAEyWyBW8XAGg8T
+      JO1xMU0VP2wZxhLumH2pXicZy2UuNDQzY2Vfs7b3lny2ZNvqFonspDN/8mf+iIni
+      ZObrqIVIw6NcMFowHQYDVR0OBBYEFOMvj2LPGlkOw1M1Pj34klVi8SFgMA8GA1Ud
+      EwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMBgGA1UdEQQRMA+BDXRlc3RAdHdn
+      Yy5jb20wCgYIKoEcz1UBg3UDSAAwRQIgTeoLjt+eP3kwQg17G+l12wj4MQNed1hW
+      aZZkJe43rkICIQCdI3WhnrvzhbEijsTXL1woIwnFgY9MIci7BmKLMpMM6w==
+      -----END CERTIFICATE-----


### PR DESCRIPTION
- 新增: `SM2Util#loadPrivFromString`;
- 新增: `SM2Util#loadPublicFromString`;
- 新增: `SM2Util#loadX509CertificateFromString`;
-  新增: 以上三方法对应的测试用例;